### PR TITLE
chore: fix npm git dep install — prepare runs build:src only

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "clear:dist": "rm -rf dist/",
     "clear:docs": "rm -rf docs/",
-    "prepublish": "yarn build",
+    "prepare": "yarn build:src",
+    "prepublishOnly": "yarn build",
     "prebuild": "yarn clear:dist; yarn clear:docs;",
     "build": "yarn build:src; yarn build:docs",
     "prebuild:docs": "yarn clear:docs",


### PR DESCRIPTION
## Problem

When `composited-card` is installed as a git dependency (`github:immutable/gu-composited-card#master`), npm runs the `prepublish` script which triggers `yarn build` — including `build:docs` which fails in CI environments.

## Fix

- Rename `prepublish` → `prepublishOnly` so it only runs on actual `npm publish`
- Add `prepare` script that runs only `build:src` — this is what npm executes for git dep installs (npm 5+)

This lets `gu-backend-card-image` install `composited-card` from the git ref without triggering the docs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)