### PR TITLE
chore: fix webpack 4 / Node 17+ OpenSSL error in prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "clear:dist": "rm -rf dist/",
     "clear:docs": "rm -rf docs/",
-    "prepare": "yarn build:src",
+    "prepare": "NODE_OPTIONS=--openssl-legacy-provider yarn build:src",
     "prepublishOnly": "yarn build",
     "prebuild": "yarn clear:dist; yarn clear:docs;",
     "build": "yarn build:src; yarn build:docs",


### PR DESCRIPTION
Webpack 4's Terser plugin uses legacy OpenSSL APIs incompatible with Node 17+. CI runners use Node 18+ which triggers `error:0308010C:digital envelope routines::unsupported`.

Adds `NODE_OPTIONS=--openssl-legacy-provider` to the `prepare` script so git dep installs succeed on modern Node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)