### PR TITLE
(DO NOT MERGE) Feature/artist tool

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "artist-tool",
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": ["dev:artist"],
+      "port": 9001
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 /.cache
 .DS_Store
+/artist/uploads/

--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ load up a test page, with many different card types and sizes
 $ yarn dev:demo
 ```
 
+## Artist Tool
+
+A local tool for artists to preview a card's full frame/composition with their own custom illustration, without needing real card/proto data. Fill in the card data (type, name, rarity, set, tribe, mana, attack/health, effect, etc.) and upload a jpg to see it composited into an actual card — including background color and preview size controls. Inputs are saved to local storage, so they persist between reloads.
+
+```bash
+$ yarn dev:artist
+```
+
 ## For component contributers
 
 ### Install dependencies

--- a/artist/artist.html
+++ b/artist/artist.html
@@ -206,7 +206,9 @@
         </form>
 
         <div class="actions" style="margin-top: 10px;">
-          <button type="button" id="export-btn">Export SVG</button>
+          <span style="line-height: 40px">Export</span>
+          <button type="button" id="export-png-btn">PNG</button>
+          <button type="button" id="export-svg-btn">SVG</button>
         </div>
         <div id="export-status"></div>
       </aside>

--- a/artist/artist.html
+++ b/artist/artist.html
@@ -1,0 +1,210 @@
+<html>
+  <head>
+    <title>GU Card Artist Tool</title>
+    <style>
+      body {
+        margin: 0;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      }
+      .layout {
+        display: flex;
+        min-height: 100vh;
+      }
+      .card-wrapper {
+        flex: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 40px;
+        background: #202020;
+      }
+      #card-mount {
+        width: 400px;
+      }
+      #empty-state {
+        color: #999;
+        font-size: 14px;
+      }
+      .sidebar {
+        width: 360px;
+        flex-shrink: 0;
+        padding: 24px;
+        background: #f4f4f4;
+        overflow-y: auto;
+        box-sizing: border-box;
+      }
+      .sidebar h2 {
+        margin-top: 0;
+        font-size: 16px;
+      }
+      .field {
+        display: block;
+        margin-bottom: 14px;
+        font-size: 13px;
+        font-weight: 600;
+        color: #333;
+      }
+      .field input,
+      .field select,
+      .field textarea {
+        display: block;
+        width: 100%;
+        margin-top: 4px;
+        padding: 6px 8px;
+        font-size: 13px;
+        font-weight: normal;
+        box-sizing: border-box;
+      }
+      .field-row {
+        display: flex;
+        gap: 10px;
+      }
+      .field-row .field {
+        flex: 1;
+      }
+      #current-art-preview {
+        margin-top: 6px;
+        font-size: 12px;
+        color: #666;
+      }
+      #current-art-preview img {
+        max-width: 100%;
+        display: block;
+        margin-top: 4px;
+        border: 1px solid #ccc;
+      }
+      .actions {
+        display: flex;
+        gap: 8px;
+        margin-top: 20px;
+      }
+      .actions button {
+        flex: 1;
+        padding: 10px;
+        font-size: 14px;
+        cursor: pointer;
+      }
+      .view-settings {
+        margin-bottom: 20px;
+        padding-bottom: 16px;
+        border-bottom: 1px solid #ddd;
+      }
+      .color-field {
+        display: flex;
+        gap: 6px;
+        margin-top: 4px;
+      }
+      .color-field input[type='text'] {
+        flex: 1;
+        margin-top: 0;
+      }
+      .color-field input[type='color'] {
+        width: 40px;
+        padding: 0;
+        border: 1px solid #ccc;
+        cursor: pointer;
+      }
+      .slider-value {
+        font-weight: normal;
+        color: #666;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="layout">
+      <div class="card-wrapper" id="card-wrapper">
+        <div id="card-mount"></div>
+        <div id="empty-state">No card yet — fill in the form and click Generate.</div>
+      </div>
+
+      <aside class="sidebar">
+        <h2>View</h2>
+        <div class="view-settings">
+          <label class="field">
+            Background color
+            <div class="color-field">
+              <input type="text" id="bg-color-text" placeholder="#202020" />
+              <input type="color" id="bg-color-picker" />
+            </div>
+          </label>
+          <label class="field">
+            Size <span class="slider-value" id="size-value">400px</span>
+            <input type="range" id="size-slider" min="200" max="1500" value="400" />
+          </label>
+        </div>
+
+        <h2>Card Data</h2>
+        <form id="artist-form">
+          <label class="field">
+            Quality
+            <select name="quality" id="quality"></select>
+          </label>
+
+          <label class="field">
+            Type
+            <select name="type" id="type"></select>
+          </label>
+
+          <label class="field">
+            Name
+            <input type="text" name="name" id="name" />
+          </label>
+
+          <div class="field-row">
+            <label class="field">
+              Rarity
+              <select name="rarity" id="rarity"></select>
+            </label>
+            <label class="field">
+              God
+              <select name="god" id="god"></select>
+            </label>
+          </div>
+
+          <div class="field-row">
+            <label class="field">
+              Set
+              <select name="set" id="set"></select>
+            </label>
+            <label class="field">
+              Tribe
+              <select name="tribe" id="tribe"></select>
+            </label>
+          </div>
+
+          <div class="field-row">
+            <label class="field">
+              Mana
+              <input type="number" name="mana" id="mana" min="0" />
+            </label>
+            <label class="field">
+              Attack
+              <input type="number" name="attack" id="attack" min="0" />
+            </label>
+            <label class="field">
+              Health
+              <input type="number" name="health" id="health" min="0" />
+            </label>
+          </div>
+
+          <label class="field">
+            Effect
+            <textarea name="effect" id="effect" rows="4"></textarea>
+          </label>
+
+          <label class="field">
+            Art (jpg)
+            <input type="file" name="art" id="art" accept=".jpg,.jpeg,image/jpeg" />
+          </label>
+          <div id="current-art-preview"></div>
+
+          <div class="actions">
+            <button type="submit" id="submit-btn">Generate</button>
+            <button type="button" id="clear-btn">Clear</button>
+          </div>
+        </form>
+      </aside>
+    </div>
+  </body>
+</html>

--- a/artist/artist.html
+++ b/artist/artist.html
@@ -204,6 +204,11 @@
             <button type="button" id="clear-btn">Clear</button>
           </div>
         </form>
+
+        <div class="actions" style="margin-top: 10px;">
+          <button type="button" id="export-btn">Export SVG</button>
+        </div>
+        <div id="export-status"></div>
       </aside>
     </div>
   </body>

--- a/artist/artist.js
+++ b/artist/artist.js
@@ -9,6 +9,7 @@ import {
   CUSTOM_ART_ID,
   CUSTOM_ART_BASE_PATH,
 } from './config';
+import { resolveComposition } from './composition-resolver';
 
 const STORAGE_KEY = 'gu-artist-tool-form';
 const TEXT_FIELDS = ['quality', 'type', 'name', 'rarity', 'god', 'set', 'tribe', 'mana', 'attack', 'health', 'effect'];
@@ -40,11 +41,28 @@ const selectFieldOptions = {
   tribe: tribeOptions,
 };
 
+function renderGroupedOptions(options) {
+  const groups = new Map();
+  options.forEach((opt) => {
+    if (!groups.has(opt.group)) groups.set(opt.group, []);
+    groups.get(opt.group).push(opt);
+  });
+  return Array.from(groups.entries())
+    .map(
+      ([group, opts]) => `
+        <optgroup label="${group}">
+          ${opts.map((opt) => `<option value="${opt.value}">${opt.label}</option>`).join('')}
+        </optgroup>
+      `,
+    )
+    .join('');
+}
+
 function populateSelects() {
   Object.entries(selectFieldOptions).forEach(([fieldName, options]) => {
-    form.elements[fieldName].innerHTML = options
-      .map((opt) => `<option value="${opt.value}">${opt.label}</option>`)
-      .join('');
+    form.elements[fieldName].innerHTML = options.length && options[0].group
+      ? renderGroupedOptions(options)
+      : options.map((opt) => `<option value="${opt.value}">${opt.label}</option>`).join('');
   });
 }
 
@@ -66,8 +84,17 @@ function applyDataToForm(data) {
   toggleCreatureFields();
 }
 
-function buildInputProtoData(data) {
-  const protoData = {
+function getQualityOption(value) {
+  return qualityOptions.find((opt) => opt.value === value);
+}
+
+// Basic qualities render via compositionVersion=1 (inputProtoData + quality
+// number), unchanged. Variant/image qualities render via
+// compositionVersion=2 — the composition object is resolved from
+// quality.json's class_properties (see composition-resolver.js).
+function buildCardProps(data) {
+  const qualityOption = getQualityOption(data.quality);
+  const cardData = {
     id: CUSTOM_ART_ID,
     type: data.type,
     name: data.name,
@@ -77,29 +104,52 @@ function buildInputProtoData(data) {
     mana: Number(data.mana),
     effect: data.effect,
   };
-  if (data.tribe && data.tribe !== 'none') protoData.tribe = data.tribe;
+  if (data.tribe && data.tribe !== 'none') cardData.tribe = data.tribe;
   if (data.type === 'creature') {
-    protoData.attack = Number(data.attack);
-    protoData.health = Number(data.health);
+    cardData.attack = Number(data.attack);
+    cardData.health = Number(data.health);
   }
-  return protoData;
+
+  if (!qualityOption || qualityOption.compositionVersion === 1) {
+    return { compositionVersion: 1, cardData };
+  }
+
+  return {
+    compositionVersion: 2,
+    cardData: { ...cardData, composition: resolveComposition(qualityOption.classProperties, cardData) },
+  };
 }
+
+// Kept so the size slider can update the already-mounted card's
+// responsiveSrcsetSizes live, instead of only applying on next Generate.
+let currentCard = null;
 
 function renderCard(data, hasArt) {
   cardMount.innerHTML = '';
+  currentCard = null;
   if (!data || !hasArt) {
     emptyState.style.display = 'block';
     return;
   }
   emptyState.style.display = 'none';
 
+  const { compositionVersion, cardData } = buildCardProps(data);
+
   const card = document.createElement('composited-card');
   card.style.width = '100%';
-  card.quality = Number(data.quality);
-  card.responsiveSrcsetSizes = '320px';
+  card.responsiveSrcsetSizes = `${loadViewSettings().size}px`;
   card.illustrationSource = `${window.location.origin}${CUSTOM_ART_BASE_PATH}`;
-  card.inputProtoData = buildInputProtoData(data);
+  card.compositionVersion = compositionVersion;
+
+  if (compositionVersion === 1) {
+    card.quality = Number(data.quality);
+    card.inputProtoData = cardData;
+  } else {
+    card.inputCompositionData = cardData;
+  }
+
   cardMount.appendChild(card);
+  currentCard = card;
 }
 
 function renderArtPreview(hasArt) {
@@ -194,6 +244,7 @@ function initViewSettings() {
     const value = Number(sizeSlider.value);
     applySize(value);
     saveViewSettings({ ...loadViewSettings(), size: value });
+    if (currentCard) currentCard.responsiveSrcsetSizes = `${value}px`;
   });
 }
 

--- a/artist/artist.js
+++ b/artist/artist.js
@@ -10,6 +10,7 @@ import {
   CUSTOM_ART_BASE_PATH,
 } from './config';
 import { resolveComposition } from './composition-resolver';
+import { exportCardAsSvg } from './export-card';
 
 const STORAGE_KEY = 'gu-artist-tool-form';
 const TEXT_FIELDS = ['quality', 'type', 'name', 'rarity', 'god', 'set', 'tribe', 'mana', 'attack', 'health', 'effect'];
@@ -27,6 +28,8 @@ const cardMount = document.getElementById('card-mount');
 const emptyState = document.getElementById('empty-state');
 const artPreview = document.getElementById('current-art-preview');
 const clearBtn = document.getElementById('clear-btn');
+const exportBtn = document.getElementById('export-btn');
+const exportStatus = document.getElementById('export-status');
 const bgColorText = document.getElementById('bg-color-text');
 const bgColorPicker = document.getElementById('bg-color-picker');
 const sizeSlider = document.getElementById('size-slider');
@@ -196,6 +199,32 @@ async function handleClear(event) {
   window.location.reload();
 }
 
+async function handleExport() {
+  if (!currentCard) {
+    exportStatus.textContent = 'Generate a card first.';
+    return;
+  }
+
+  exportBtn.disabled = true;
+  exportBtn.textContent = 'Exporting…';
+  exportStatus.textContent = '';
+
+  try {
+    const blob = await exportCardAsSvg(currentCard);
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${(form.elements.name.value || 'card').trim().replace(/\s+/g, '-')}.svg`;
+    a.click();
+    URL.revokeObjectURL(url);
+  } catch (err) {
+    exportStatus.textContent = `Export failed: ${err.message}`;
+  } finally {
+    exportBtn.disabled = false;
+    exportBtn.textContent = 'Export SVG';
+  }
+}
+
 function loadViewSettings() {
   const raw = localStorage.getItem(VIEW_STORAGE_KEY);
   return raw ? { ...DEFAULT_VIEW_SETTINGS, ...JSON.parse(raw) } : { ...DEFAULT_VIEW_SETTINGS };
@@ -259,6 +288,7 @@ async function init() {
   form.elements.type.addEventListener('change', toggleCreatureFields);
   form.addEventListener('submit', handleSubmit);
   clearBtn.addEventListener('click', handleClear);
+  exportBtn.addEventListener('click', handleExport);
 
   const hasArt = await checkArtExists();
   renderArtPreview(hasArt);

--- a/artist/artist.js
+++ b/artist/artist.js
@@ -1,0 +1,217 @@
+import '../src/composited-card.component';
+import {
+  qualityOptions,
+  typeOptions,
+  rarityOptions,
+  godOptions,
+  setOptions,
+  tribeOptions,
+  CUSTOM_ART_ID,
+  CUSTOM_ART_BASE_PATH,
+} from './config';
+
+const STORAGE_KEY = 'gu-artist-tool-form';
+const TEXT_FIELDS = ['quality', 'type', 'name', 'rarity', 'god', 'set', 'tribe', 'mana', 'attack', 'health', 'effect'];
+
+// View settings (background color, preview size) are kept separate from the
+// card-data form above — they're viewer preferences, not card data, so they
+// apply live and survive a "Clear" (which only resets card data + art).
+const VIEW_STORAGE_KEY = 'gu-artist-tool-view';
+const DEFAULT_VIEW_SETTINGS = { bgColor: '#202020', size: 400 };
+const HEX_COLOR_RE = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i;
+
+const form = document.getElementById('artist-form');
+const cardWrapper = document.getElementById('card-wrapper');
+const cardMount = document.getElementById('card-mount');
+const emptyState = document.getElementById('empty-state');
+const artPreview = document.getElementById('current-art-preview');
+const clearBtn = document.getElementById('clear-btn');
+const bgColorText = document.getElementById('bg-color-text');
+const bgColorPicker = document.getElementById('bg-color-picker');
+const sizeSlider = document.getElementById('size-slider');
+const sizeValueLabel = document.getElementById('size-value');
+
+const selectFieldOptions = {
+  quality: qualityOptions,
+  type: typeOptions,
+  rarity: rarityOptions,
+  god: godOptions,
+  set: setOptions,
+  tribe: tribeOptions,
+};
+
+function populateSelects() {
+  Object.entries(selectFieldOptions).forEach(([fieldName, options]) => {
+    form.elements[fieldName].innerHTML = options
+      .map((opt) => `<option value="${opt.value}">${opt.label}</option>`)
+      .join('');
+  });
+}
+
+function toggleCreatureFields() {
+  const isCreature = form.elements.type.value === 'creature';
+  form.elements.attack.disabled = !isCreature;
+  form.elements.health.disabled = !isCreature;
+}
+
+function loadStoredData() {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  return raw ? JSON.parse(raw) : null;
+}
+
+function applyDataToForm(data) {
+  TEXT_FIELDS.forEach((key) => {
+    if (data[key] !== undefined) form.elements[key].value = data[key];
+  });
+  toggleCreatureFields();
+}
+
+function buildInputProtoData(data) {
+  const protoData = {
+    id: CUSTOM_ART_ID,
+    type: data.type,
+    name: data.name,
+    rarity: data.rarity,
+    god: data.god,
+    set: data.set,
+    mana: Number(data.mana),
+    effect: data.effect,
+  };
+  if (data.tribe && data.tribe !== 'none') protoData.tribe = data.tribe;
+  if (data.type === 'creature') {
+    protoData.attack = Number(data.attack);
+    protoData.health = Number(data.health);
+  }
+  return protoData;
+}
+
+function renderCard(data, hasArt) {
+  cardMount.innerHTML = '';
+  if (!data || !hasArt) {
+    emptyState.style.display = 'block';
+    return;
+  }
+  emptyState.style.display = 'none';
+
+  const card = document.createElement('composited-card');
+  card.style.width = '100%';
+  card.quality = Number(data.quality);
+  card.responsiveSrcsetSizes = '320px';
+  card.illustrationSource = `${window.location.origin}${CUSTOM_ART_BASE_PATH}`;
+  card.inputProtoData = buildInputProtoData(data);
+  cardMount.appendChild(card);
+}
+
+function renderArtPreview(hasArt) {
+  artPreview.innerHTML = hasArt
+    ? `Current art:<img src="${CUSTOM_ART_BASE_PATH}/art2/256/${CUSTOM_ART_ID}.jpg?t=${Date.now()}" alt="current art" />`
+    : 'No artwork uploaded yet.';
+}
+
+async function checkArtExists() {
+  const res = await fetch('/api/upload-art/status');
+  const { exists } = await res.json();
+  return exists;
+}
+
+function collectFormData() {
+  const data = {};
+  TEXT_FIELDS.forEach((key) => {
+    data[key] = form.elements[key].value;
+  });
+  return data;
+}
+
+async function handleSubmit(event) {
+  event.preventDefault();
+  const data = collectFormData();
+  const file = form.elements.art.files[0];
+
+  if (file) {
+    await fetch('/api/upload-art', {
+      method: 'POST',
+      headers: { 'Content-Type': file.type || 'image/jpeg' },
+      body: file,
+    });
+  }
+
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  window.location.reload();
+}
+
+async function handleClear(event) {
+  event.preventDefault();
+  localStorage.removeItem(STORAGE_KEY);
+  await fetch('/api/upload-art', { method: 'DELETE' });
+  window.location.reload();
+}
+
+function loadViewSettings() {
+  const raw = localStorage.getItem(VIEW_STORAGE_KEY);
+  return raw ? { ...DEFAULT_VIEW_SETTINGS, ...JSON.parse(raw) } : { ...DEFAULT_VIEW_SETTINGS };
+}
+
+function saveViewSettings(settings) {
+  localStorage.setItem(VIEW_STORAGE_KEY, JSON.stringify(settings));
+}
+
+function applyBackgroundColor(color) {
+  cardWrapper.style.background = color;
+}
+
+function applySize(size) {
+  cardMount.style.width = `${size}px`;
+  sizeValueLabel.textContent = `${size}px`;
+}
+
+function initViewSettings() {
+  const settings = loadViewSettings();
+
+  bgColorText.value = settings.bgColor;
+  bgColorPicker.value = HEX_COLOR_RE.test(settings.bgColor) && settings.bgColor.length === 7
+    ? settings.bgColor
+    : DEFAULT_VIEW_SETTINGS.bgColor;
+  sizeSlider.value = settings.size;
+  applyBackgroundColor(settings.bgColor);
+  applySize(settings.size);
+
+  bgColorText.addEventListener('input', () => {
+    const value = bgColorText.value.trim();
+    if (!HEX_COLOR_RE.test(value)) return;
+    applyBackgroundColor(value);
+    if (value.length === 7) bgColorPicker.value = value;
+    saveViewSettings({ ...loadViewSettings(), bgColor: value });
+  });
+
+  bgColorPicker.addEventListener('input', () => {
+    const value = bgColorPicker.value;
+    bgColorText.value = value;
+    applyBackgroundColor(value);
+    saveViewSettings({ ...loadViewSettings(), bgColor: value });
+  });
+
+  sizeSlider.addEventListener('input', () => {
+    const value = Number(sizeSlider.value);
+    applySize(value);
+    saveViewSettings({ ...loadViewSettings(), size: value });
+  });
+}
+
+async function init() {
+  populateSelects();
+  initViewSettings();
+
+  const stored = loadStoredData();
+  if (stored) applyDataToForm(stored);
+  else toggleCreatureFields();
+
+  form.elements.type.addEventListener('change', toggleCreatureFields);
+  form.addEventListener('submit', handleSubmit);
+  clearBtn.addEventListener('click', handleClear);
+
+  const hasArt = await checkArtExists();
+  renderArtPreview(hasArt);
+  renderCard(stored, hasArt);
+}
+
+init();

--- a/artist/artist.js
+++ b/artist/artist.js
@@ -10,7 +10,7 @@ import {
   CUSTOM_ART_BASE_PATH,
 } from './config';
 import { resolveComposition } from './composition-resolver';
-import { exportCardAsSvg } from './export-card';
+import { exportCardAsSvg, exportCardAsPng } from './export-card';
 
 const STORAGE_KEY = 'gu-artist-tool-form';
 const TEXT_FIELDS = ['quality', 'type', 'name', 'rarity', 'god', 'set', 'tribe', 'mana', 'attack', 'health', 'effect'];
@@ -28,7 +28,8 @@ const cardMount = document.getElementById('card-mount');
 const emptyState = document.getElementById('empty-state');
 const artPreview = document.getElementById('current-art-preview');
 const clearBtn = document.getElementById('clear-btn');
-const exportBtn = document.getElementById('export-btn');
+const exportPngBtn = document.getElementById('export-png-btn');
+const exportSvgBtn = document.getElementById('export-svg-btn');
 const exportStatus = document.getElementById('export-status');
 const bgColorText = document.getElementById('bg-color-text');
 const bgColorPicker = document.getElementById('bg-color-picker');
@@ -199,29 +200,33 @@ async function handleClear(event) {
   window.location.reload();
 }
 
-async function handleExport() {
+async function handleExport(format) {
   if (!currentCard) {
     exportStatus.textContent = 'Generate a card first.';
     return;
   }
 
-  exportBtn.disabled = true;
-  exportBtn.textContent = 'Exporting…';
+  const btn = format === 'png' ? exportPngBtn : exportSvgBtn;
+  const originalLabel = btn.textContent;
+  exportPngBtn.disabled = true;
+  exportSvgBtn.disabled = true;
+  btn.textContent = 'Exporting…';
   exportStatus.textContent = '';
 
   try {
-    const blob = await exportCardAsSvg(currentCard);
+    const blob = format === 'png' ? await exportCardAsPng(currentCard) : await exportCardAsSvg(currentCard);
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = `${(form.elements.name.value || 'card').trim().replace(/\s+/g, '-')}.svg`;
+    a.download = `${(form.elements.name.value || 'card').trim().replace(/\s+/g, '-')}.${format}`;
     a.click();
     URL.revokeObjectURL(url);
   } catch (err) {
     exportStatus.textContent = `Export failed: ${err.message}`;
   } finally {
-    exportBtn.disabled = false;
-    exportBtn.textContent = 'Export SVG';
+    exportPngBtn.disabled = false;
+    exportSvgBtn.disabled = false;
+    btn.textContent = originalLabel;
   }
 }
 
@@ -288,7 +293,8 @@ async function init() {
   form.elements.type.addEventListener('change', toggleCreatureFields);
   form.addEventListener('submit', handleSubmit);
   clearBtn.addEventListener('click', handleClear);
-  exportBtn.addEventListener('click', handleExport);
+  exportPngBtn.addEventListener('click', () => handleExport('png'));
+  exportSvgBtn.addEventListener('click', () => handleExport('svg'));
 
   const hasArt = await checkArtExists();
   renderArtPreview(hasArt);

--- a/artist/composition-resolver.js
+++ b/artist/composition-resolver.js
@@ -10,8 +10,16 @@
 //    "comp-rosette": ["variants", "variant_tides_1"]) -> used as-is
 //  - a template string (eg. "comp-rosette": "{god}_diamond") -> substitute
 //    placeholders, then pair with the relevant folder value (type/god)
-//  - absent -> falls back to the normal (non-quality-specific) convention,
-//    or an empty array where there's no sensible fallback (eg. tribe_bar)
+//  - absent -> falls back to the normal (non-quality-specific) convention
+//
+// The Variant family (tides/dread/fallen/guardians/ascent/root/plague) has
+// no "comp-tribe" field at all in quality.json, which looks like a missing
+// asset at first — but border-layers/tribe_bars/<size>/tribebar_<name>.webp
+// (eg. tribebar_tides) actually exists on the CDN (verified directly,
+// 200 for all 7), just under the plain "tribebar_{name}" convention used by
+// basic qualities rather than the "variant_{name}_1" pattern frame/rosette/
+// wreath use for these qualities. So the tribe_bar fallback below isn't an
+// empty array — it's the same convention "comp-gems" already falls back to.
 
 function substitute(template, vars) {
   return template.replace(/\{(\w+)\}/g, (_, key) => vars[key] || '');
@@ -44,7 +52,7 @@ export function resolveComposition(classProperties, card) {
     gems: resolveFlatField(props['comp-gems'] !== undefined ? props['comp-gems'] : `rarity_${card.rarity}`, vars),
     wreath: resolveFlatField(props['comp-wreath'], vars),
     lock: [],
-    tribe_bar: resolveFlatField(props['comp-tribe'], vars),
+    tribe_bar: resolveFlatField(props['comp-tribe'] !== undefined ? props['comp-tribe'] : `tribebar_${props.name}`, vars),
     set: props['comp-set'] !== undefined ? props['comp-set'] : [card.set],
   };
 }

--- a/artist/composition-resolver.js
+++ b/artist/composition-resolver.js
@@ -1,0 +1,50 @@
+// Builds the ICompositionData shape (frame/rosette/gems/wreath/lock/
+// tribe_bar/set) that compositionVersion=2 rendering expects, from a
+// quality.json class_properties entry plus the card's own type/god/id/set/
+// rarity. Only needed for qualities that have comp-* fields at all — the 5
+// basic qualities don't, and keep rendering via compositionVersion=1
+// unchanged (see artist.js).
+//
+// Each comp-* field is either:
+//  - already a fully-resolved array (eg. a variant quality's
+//    "comp-rosette": ["variants", "variant_tides_1"]) -> used as-is
+//  - a template string (eg. "comp-rosette": "{god}_diamond") -> substitute
+//    placeholders, then pair with the relevant folder value (type/god)
+//  - absent -> falls back to the normal (non-quality-specific) convention,
+//    or an empty array where there's no sensible fallback (eg. tribe_bar)
+
+function substitute(template, vars) {
+  return template.replace(/\{(\w+)\}/g, (_, key) => vars[key] || '');
+}
+
+// For fields whose rendered URL is `.../<folder>/<size>/<filename>` (frame
+// uses type as the folder, rosette uses god).
+function resolveFolderField(rawValue, folderValue, vars) {
+  if (Array.isArray(rawValue)) return rawValue;
+  if (typeof rawValue !== 'string') return [];
+  return [folderValue, substitute(rawValue, vars)];
+}
+
+// For fields whose rendered URL is `.../<size>/<filename>` (no folder
+// segment derived from the card itself).
+function resolveFlatField(rawValue, vars) {
+  if (Array.isArray(rawValue)) return rawValue;
+  if (typeof rawValue !== 'string') return [];
+  return [substitute(rawValue, vars)];
+}
+
+export function resolveComposition(classProperties, card) {
+  const vars = { type: card.type, god: card.god, id: card.id };
+  const props = classProperties;
+
+  return {
+    illustration: [card.id],
+    frame: resolveFolderField(props['comp-frame'], card.type, vars),
+    rosette: resolveFolderField(props['comp-rosette'], card.god, vars),
+    gems: resolveFlatField(props['comp-gems'] !== undefined ? props['comp-gems'] : `rarity_${card.rarity}`, vars),
+    wreath: resolveFlatField(props['comp-wreath'], vars),
+    lock: [],
+    tribe_bar: resolveFlatField(props['comp-tribe'], vars),
+    set: props['comp-set'] !== undefined ? props['comp-set'] : [card.set],
+  };
+}

--- a/artist/config.js
+++ b/artist/config.js
@@ -1,0 +1,92 @@
+import qualityData from './data/quality.json';
+
+// Only the 5 basic qualities are wired up for now — the rest of
+// data/quality.json (variants, mythic, animated, 11-34) needs a composition
+// (v2) resolver that substitutes {type}/{god}/{id} into class_properties,
+// which doesn't exist yet. Kept the full source file copied in so that
+// resolver can be built later without re-sourcing the data.
+const BASIC_QUALITY_VALUES = ['1', '2', '3', '4', '5'];
+
+export const qualityOptions = qualityData
+  .filter((entry) => BASIC_QUALITY_VALUES.includes(entry.class_value))
+  .map((entry) => ({ value: entry.class_value, label: entry.class_properties.name }))
+  .sort((a, b) => Number(a.value) - Number(b.value));
+
+export const typeOptions = [
+  { value: 'creature', label: 'Creature' },
+  { value: 'spell', label: 'Spell' },
+];
+
+export const rarityOptions = [
+  { value: 'common', label: 'Common' },
+  { value: 'rare', label: 'Rare' },
+  { value: 'epic', label: 'Epic' },
+  { value: 'legendary', label: 'Legendary' },
+  { value: 'mythic', label: 'Mythic' },
+];
+
+export const godOptions = [
+  { value: 'war', label: 'War' },
+  { value: 'magic', label: 'Magic' },
+  { value: 'death', label: 'Death' },
+  { value: 'deception', label: 'Deception' },
+  { value: 'nature', label: 'Nature' },
+  { value: 'light', label: 'Light' },
+];
+
+// mirrors CardSet.cs's NamesMap — already-lowercase values. "etherbots"
+// (plural) is used rather than the enum Map's "etherbot" backward-compat
+// quirk, since that's the spelling composited-card's own README documents.
+export const setOptions = [
+  { value: 'genesis', label: 'Genesis' },
+  { value: 'core', label: 'Core' },
+  { value: 'etherbots', label: 'Etherbots' },
+  { value: 'promo', label: 'Promotion' },
+  { value: 'mythic', label: 'Mythic' },
+  { value: 'trial', label: 'Trial of the Gods' },
+  { value: 'welcome', label: 'Welcome set' },
+  { value: 'order', label: 'Divine Order' },
+  { value: 'mortal', label: 'Mortal Judgement' },
+  { value: 'verdict', label: "Light's Verdict" },
+  { value: 'wander', label: 'Winter Wanderlands' },
+  { value: 'wolf', label: 'Band of the Wolf' },
+  { value: 'atlantis', label: 'Atlantis' },
+  { value: 'tides', label: 'Tides' },
+  { value: 'dread', label: 'Dread Awakening' },
+  { value: 'tower', label: 'Tower of Dread' },
+  { value: 'fallen', label: 'Fallen Age' },
+  { value: 'guardians', label: 'Guardians' },
+  { value: 'revival', label: 'Revival' },
+  { value: 'ascent', label: 'Age of Ascent' },
+  { value: 'roots', label: 'Roots of Ruin' },
+  { value: 'spoils', label: 'Spoils' },
+  { value: 'plague', label: 'The Waking Plague' },
+];
+
+// mirrors TribeType.cs's NamesMap. "none" is handled specially in
+// artist.js's submit handler — it's omitted from the card data entirely
+// (not passed as the literal string "none"), matching the tribe-bar
+// Valid/String gating fixed in composited-card.component.ts.
+export const tribeOptions = [
+  { value: 'none', label: 'None' },
+  { value: 'aether', label: 'Aether' },
+  { value: 'amazon', label: 'Amazon' },
+  { value: 'anubian', label: 'Anubian' },
+  { value: 'atlantean', label: 'Atlantean' },
+  { value: 'dragon', label: 'Dragon' },
+  { value: 'nether', label: 'Nether' },
+  { value: 'olympian', label: 'Olympian' },
+  { value: 'viking', label: 'Viking' },
+  { value: 'guild', label: 'Guild' },
+  { value: 'mystic', label: 'Mystic' },
+  { value: 'structure', label: 'Structure' },
+  { value: 'wild', label: 'Wild' },
+  { value: 'pet', label: 'Pet' },
+  { value: 'guardian', label: 'Guardian' },
+  { value: 'everborn', label: 'Everborn' },
+];
+
+// Fixed illustration id/base path — the uploaded art always overwrites the
+// same file, so there's no need for a real per-card id here.
+export const CUSTOM_ART_ID = 'custom-art';
+export const CUSTOM_ART_BASE_PATH = '/custom-art';

--- a/artist/config.js
+++ b/artist/config.js
@@ -1,15 +1,43 @@
 import qualityData from './data/quality.json';
 
-// Only the 5 basic qualities are wired up for now — the rest of
-// data/quality.json (variants, mythic, animated, 11-34) needs a composition
-// (v2) resolver that substitutes {type}/{god}/{id} into class_properties,
-// which doesn't exist yet. Kept the full source file copied in so that
-// resolver can be built later without re-sourcing the data.
-const BASIC_QUALITY_VALUES = ['1', '2', '3', '4', '5'];
+// Basic qualities render via compositionVersion=1 (unchanged, no comp-*
+// fields exist for these). Variant/image qualities render via
+// compositionVersion=2, resolved through composition-resolver.js.
+// "-animated" qualities (31-34) need real video assets we don't handle, and
+// "mythic" (15) needs a real pre-existing card's art_id to resolve its
+// frame/rosette/wreath — neither works generically for a prototype card, so
+// both are excluded here.
+const QUALITY_FAMILY = {
+  1: 'Basic',
+  2: 'Basic',
+  3: 'Basic',
+  4: 'Basic',
+  5: 'Basic',
+  11: 'Variant',
+  12: 'Variant',
+  13: 'Variant',
+  14: 'Variant',
+  16: 'Variant',
+  17: 'Variant',
+  18: 'Variant',
+  21: 'Image',
+  22: 'Image',
+  23: 'Image',
+  24: 'Image',
+};
 
 export const qualityOptions = qualityData
-  .filter((entry) => BASIC_QUALITY_VALUES.includes(entry.class_value))
-  .map((entry) => ({ value: entry.class_value, label: entry.class_properties.name }))
+  .filter((entry) => QUALITY_FAMILY[entry.class_value] !== undefined)
+  .map((entry) => {
+    const family = QUALITY_FAMILY[entry.class_value];
+    return {
+      value: entry.class_value,
+      label: entry.class_properties.name,
+      group: family,
+      compositionVersion: family === 'Basic' ? 1 : 2,
+      classProperties: family === 'Basic' ? null : entry.class_properties,
+    };
+  })
   .sort((a, b) => Number(a.value) - Number(b.value));
 
 export const typeOptions = [

--- a/artist/data/quality.json
+++ b/artist/data/quality.json
@@ -1,0 +1,670 @@
+[
+  {
+    "class_key": "quality",
+    "class_value": "1",
+    "class_properties": {
+      "name": "diamond",
+      "shine": 1
+    },
+    "class_royalties": [
+      {
+        "percentage": 0.1,
+        "recipient": "starkware"
+      },
+      {
+        "percentage": 0.3,
+        "recipient": "gu"
+      },
+      {
+        "percentage": 0.1,
+        "recipient": "gu-staking"
+      }
+    ],
+    "class_type": "card",
+    "game_id": 1
+  },
+  {
+    "class_key": "quality",
+    "class_value": "2",
+    "class_properties": {
+      "name": "gold",
+      "shine": 2
+    },
+    "class_royalties": [
+      {
+        "percentage": 0.6,
+        "recipient": "starkware"
+      },
+      {
+        "percentage": 1.8,
+        "recipient": "gu"
+      },
+      {
+        "percentage": 0.6,
+        "recipient": "gu-staking"
+      }
+    ],
+    "class_type": "card",
+    "game_id": 1
+  },
+  {
+    "class_key": "quality",
+    "class_value": "3",
+    "class_properties": {
+      "name": "shadow",
+      "shine": 3
+    },
+    "class_royalties": [
+      {
+        "percentage": 0.8,
+        "recipient": "starkware"
+      },
+      {
+        "percentage": 2.4,
+        "recipient": "gu"
+      },
+      {
+        "percentage": 0.8,
+        "recipient": "gu-staking"
+      }
+    ],
+    "class_type": "card",
+    "game_id": 1
+  },
+  {
+    "class_key": "quality",
+    "class_value": "4",
+    "class_properties": {
+      "name": "meteorite",
+      "shine": 4
+    },
+    "class_royalties": [
+      {
+        "percentage": 1,
+        "recipient": "starkware"
+      },
+      {
+        "percentage": 3,
+        "recipient": "gu"
+      },
+      {
+        "percentage": 1,
+        "recipient": "gu-staking"
+      }
+    ],
+    "class_type": "card",
+    "game_id": 1
+  },
+  {
+    "class_key": "quality",
+    "class_value": "5",
+    "class_properties": {
+      "name": "plain",
+      "shine": 5
+    },
+    "class_royalties": [],
+    "class_type": "card",
+    "game_id": 1
+  },
+  {
+    "class_key": "quality",
+    "class_value": "11",
+    "class_properties": {
+      "comp-frame": "variant_tides_1",
+      "comp-gems": [],
+      "comp-illustration": "tides",
+      "comp-profile": "tides",
+      "comp-rosette": [
+        "variants",
+        "variant_tides_1"
+      ],
+      "comp-set": [],
+      "comp-wreath": "variant_tides_1",
+      "frame": "tides",
+      "illustration": "tides",
+      "meta-frame": "Tides",
+      "meta-quality_name": "Variant",
+      "name": "tides",
+      "shine": 0
+    },
+    "class_royalties": [
+      {
+        "percentage": 0.1,
+        "recipient": "starkware"
+      },
+      {
+        "percentage": 0.3,
+        "recipient": "gu"
+      },
+      {
+        "percentage": 0.1,
+        "recipient": "gu-staking"
+      }
+    ],
+    "class_type": "card",
+    "game_id": 1
+  },
+  {
+    "class_key": "quality",
+    "class_value": "16",
+    "class_properties": {
+      "comp-frame": "variant_ascent_1",
+      "comp-gems": [],
+      "comp-illustration": "ascent",
+      "comp-profile": "ascent",
+      "comp-rosette": [
+        "variants",
+        "variant_ascent_1"
+      ],
+      "comp-set": [],
+      "comp-wreath": "variant_ascent_1",
+      "frame": "ascent",
+      "illustration": "ascent",
+      "meta-frame": "ascent",
+      "meta-quality_name": "Variant",
+      "name": "ascent",
+      "shine": 0
+    },
+    "class_royalties": [
+      {
+        "percentage": 0.1,
+        "recipient": "starkware"
+      },
+      {
+        "percentage": 0.3,
+        "recipient": "gu"
+      },
+      {
+        "percentage": 0.1,
+        "recipient": "gu-staking"
+      }
+    ],
+    "class_type": "card",
+    "game_id": 1
+  },
+  {
+    "class_key": "quality",
+    "class_value": "12",
+    "class_properties": {
+      "comp-frame": "variant_dread_1",
+      "comp-gems": [],
+      "comp-illustration": "dread",
+      "comp-profile": "dread",
+      "comp-rosette": [
+        "variants",
+        "variant_dread_1"
+      ],
+      "comp-set": [],
+      "comp-wreath": "variant_dread_1",
+      "frame": "dread",
+      "illustration": "dread",
+      "meta-frame": "Dread",
+      "meta-quality_name": "Variant",
+      "name": "dread",
+      "shine": 0
+    },
+    "class_royalties": [
+      {
+        "percentage": 0.1,
+        "recipient": "starkware"
+      },
+      {
+        "percentage": 0.3,
+        "recipient": "gu"
+      },
+      {
+        "percentage": 0.1,
+        "recipient": "gu-staking"
+      }
+    ],
+    "class_type": "card",
+    "game_id": 1
+  },
+  {
+    "class_key": "quality",
+    "class_value": "21",
+    "class_properties": {
+      "comp-frame": "{type}_diamond",
+      "comp-illustration": "img1",
+      "comp-profile": "diamond",
+      "comp-rosette": "{god}_diamond",
+      "comp-tribe": "tribebar_diamond",
+      "comp-wreath": "wreath_diamond",
+      "frame": "diamond",
+      "illustration": "img1",
+      "meta-quality_name": "Diamond",
+      "name": "diamond-image",
+      "shine": 1
+    },
+    "class_royalties": [
+      {
+        "percentage": 0.1,
+        "recipient": "starkware"
+      },
+      {
+        "percentage": 0.3,
+        "recipient": "gu"
+      },
+      {
+        "percentage": 0.1,
+        "recipient": "gu-staking"
+      }
+    ],
+    "class_type": "card",
+    "game_id": 1
+  },
+  {
+    "class_key": "quality",
+    "class_value": "22",
+    "class_properties": {
+      "comp-frame": "{type}_gold",
+      "comp-illustration": "img1",
+      "comp-profile": "gold",
+      "comp-rosette": "{god}_gold",
+      "comp-tribe": "tribebar_gold",
+      "comp-wreath": "wreath_gold",
+      "frame": "gold",
+      "illustration": "img1",
+      "meta-quality_name": "Gold",
+      "name": "gold-image",
+      "shine": 2
+    },
+    "class_royalties": [
+      {
+        "percentage": 0.6,
+        "recipient": "starkware"
+      },
+      {
+        "percentage": 1.8,
+        "recipient": "gu"
+      },
+      {
+        "percentage": 0.6,
+        "recipient": "gu-staking"
+      }
+    ],
+    "class_type": "card",
+    "game_id": 1
+  },
+  {
+    "class_key": "quality",
+    "class_value": "23",
+    "class_properties": {
+      "comp-frame": "{type}_shadow",
+      "comp-illustration": "img1",
+      "comp-profile": "shadow",
+      "comp-rosette": "{god}_shadow",
+      "comp-tribe": "tribebar_shadow",
+      "comp-wreath": "wreath_shadow",
+      "frame": "shadow",
+      "illustration": "img1",
+      "meta-quality_name": "Shadow",
+      "name": "shadow-image",
+      "shine": 3
+    },
+    "class_royalties": [
+      {
+        "percentage": 0.8,
+        "recipient": "starkware"
+      },
+      {
+        "percentage": 2.4,
+        "recipient": "gu"
+      },
+      {
+        "percentage": 0.8,
+        "recipient": "gu-staking"
+      }
+    ],
+    "class_type": "card",
+    "game_id": 1
+  },
+  {
+    "class_key": "quality",
+    "class_value": "24",
+    "class_properties": {
+      "comp-frame": "{type}_meteorite",
+      "comp-illustration": "img1",
+      "comp-profile": "meteorite",
+      "comp-rosette": "{god}_meteorite",
+      "comp-tribe": "tribebar_meteorite",
+      "comp-wreath": "wreath_meteorite",
+      "frame": "meteorite",
+      "illustration": "img1",
+      "meta-quality_name": "Meteorite",
+      "name": "meteorite-image",
+      "shine": 4
+    },
+    "class_royalties": [
+      {
+        "percentage": 1,
+        "recipient": "starkware"
+      },
+      {
+        "percentage": 3,
+        "recipient": "gu"
+      },
+      {
+        "percentage": 1,
+        "recipient": "gu-staking"
+      }
+    ],
+    "class_type": "card",
+    "game_id": 1
+  },
+  {
+    "class_key": "quality",
+    "class_value": "17",
+    "class_properties": {
+      "comp-frame": "variant_root_1",
+      "comp-gems": [],
+      "comp-illustration": "root",
+      "comp-profile": "root",
+      "comp-rosette": [
+        "variants",
+        "variant_root_1"
+      ],
+      "comp-set": [],
+      "comp-wreath": "variant_root_1",
+      "frame": "root",
+      "illustration": "root",
+      "meta-frame": "root",
+      "meta-quality_name": "Variant",
+      "name": "root",
+      "shine": 0
+    },
+    "class_royalties": [
+      {
+        "percentage": 0.1,
+        "recipient": "starkware"
+      },
+      {
+        "percentage": 0.3,
+        "recipient": "gu"
+      },
+      {
+        "percentage": 0.1,
+        "recipient": "gu-staking"
+      }
+    ],
+    "class_type": "card",
+    "game_id": 1
+  },
+  {
+    "class_key": "quality",
+    "class_value": "13",
+    "class_properties": {
+      "comp-frame": "variant_fallen_1",
+      "comp-gems": [],
+      "comp-illustration": "fallen",
+      "comp-profile": "fallen",
+      "comp-rosette": [
+        "variants",
+        "variant_fallen_1"
+      ],
+      "comp-set": [],
+      "comp-wreath": "variant_fallen_1",
+      "frame": "fallen",
+      "illustration": "fallen",
+      "meta-frame": "Fallen",
+      "meta-quality_name": "Variant",
+      "name": "fallen",
+      "shine": 0
+    },
+    "class_royalties": [
+      {
+        "percentage": 0.1,
+        "recipient": "starkware"
+      },
+      {
+        "percentage": 0.3,
+        "recipient": "gu"
+      },
+      {
+        "percentage": 0.1,
+        "recipient": "gu-staking"
+      }
+    ],
+    "class_type": "card",
+    "game_id": 1
+  },
+  {
+    "class_key": "quality",
+    "class_value": "14",
+    "class_properties": {
+      "comp-frame": "variant_guardians_1",
+      "comp-gems": [],
+      "comp-illustration": "guardians",
+      "comp-profile": "guardians",
+      "comp-rosette": [
+        "variants",
+        "variant_guardians_1"
+      ],
+      "comp-set": [],
+      "comp-wreath": "variant_guardians_1",
+      "frame": "guardians",
+      "illustration": "guardians",
+      "meta-frame": "guardians",
+      "meta-quality_name": "Variant",
+      "name": "guardians",
+      "shine": 0
+    },
+    "class_royalties": [
+      {
+        "percentage": 0.1,
+        "recipient": "starkware"
+      },
+      {
+        "percentage": 0.3,
+        "recipient": "gu"
+      },
+      {
+        "percentage": 0.1,
+        "recipient": "gu-staking"
+      }
+    ],
+    "class_type": "card",
+    "game_id": 1
+  },
+  {
+    "class_key": "quality",
+    "class_value": "15",
+    "class_properties": {
+      "comp-frame": "mythic_{id}",
+      "comp-gems": [],
+      "comp-illustration": "mythic",
+      "comp-profile": "mythic_{id}",
+      "comp-rosette": [
+        "mythic",
+        "mythic_{id}"
+      ],
+      "comp-set": [],
+      "comp-tribe": "mythic_{id}",
+      "comp-wreath": "mythic_{id}",
+      "frame": "",
+      "illustration": "",
+      "meta-frame": "Mythic",
+      "meta-quality_name": "Mythic",
+      "name": "mythic",
+      "shine": 0
+    },
+    "class_royalties": [
+      {
+        "percentage": 0.1,
+        "recipient": "starkware"
+      },
+      {
+        "percentage": 0.3,
+        "recipient": "gu"
+      },
+      {
+        "percentage": 0.1,
+        "recipient": "gu-staking"
+      }
+    ],
+    "class_type": "card",
+    "game_id": 1
+  },
+  {
+    "class_key": "quality",
+    "class_value": "18",
+    "class_properties": {
+      "comp-frame": "variant_plague_1",
+      "comp-gems": [],
+      "comp-illustration": "plague",
+      "comp-profile": "plague",
+      "comp-rosette": [
+        "variants",
+        "variant_plague_1"
+      ],
+      "comp-set": [],
+      "comp-wreath": "variant_plague_1",
+      "frame": "plague",
+      "illustration": "plague",
+      "meta-frame": "plague",
+      "meta-quality_name": "Variant",
+      "name": "plague",
+      "shine": 0
+    },
+    "class_royalties": [
+      {
+        "percentage": 0.1,
+        "recipient": "starkware"
+      },
+      {
+        "percentage": 0.3,
+        "recipient": "gu"
+      },
+      {
+        "percentage": 0.1,
+        "recipient": "gu-staking"
+      }
+    ],
+    "class_type": "card",
+    "game_id": 1
+  },
+  {
+    "class_key": "quality",
+    "class_value": "31",
+    "class_properties": {
+      "comp-frame": "{type}_diamond",
+      "comp-rosette": "{god}_diamond_animated",
+      "comp-tribe": "tribebar_diamond",
+      "comp-wreath": "wreath_diamond",
+      "frame": "diamond",
+      "illustration": "animated",
+      "meta-quality_name": "Diamond",
+      "name": "diamond-animated",
+      "shine": 1
+    },
+    "class_royalties": [
+      {
+        "percentage": 0.1,
+        "recipient": "starkware"
+      },
+      {
+        "percentage": 0.3,
+        "recipient": "gu"
+      },
+      {
+        "percentage": 0.1,
+        "recipient": "gu-staking"
+      }
+    ],
+    "class_type": "card",
+    "game_id": 1
+  },
+  {
+    "class_key": "quality",
+    "class_value": "32",
+    "class_properties": {
+      "comp-frame": "{type}_gold",
+      "comp-rosette": "{god}_gold_animated",
+      "comp-tribe": "tribebar_gold",
+      "comp-wreath": "wreath_gold",
+      "frame": "gold",
+      "illustration": "animated",
+      "meta-quality_name": "Gold",
+      "name": "gold-animated",
+      "shine": 2
+    },
+    "class_royalties": [
+      {
+        "percentage": 0.6,
+        "recipient": "starkware"
+      },
+      {
+        "percentage": 1.8,
+        "recipient": "gu"
+      },
+      {
+        "percentage": 0.6,
+        "recipient": "gu-staking"
+      }
+    ],
+    "class_type": "card",
+    "game_id": 1
+  },
+  {
+    "class_key": "quality",
+    "class_value": "33",
+    "class_properties": {
+      "comp-frame": "{type}_shadow",
+      "comp-rosette": "{god}_shadow_animated",
+      "comp-tribe": "tribebar_shadow",
+      "comp-wreath": "wreath_shadow",
+      "frame": "shadow",
+      "illustration": "animated",
+      "meta-quality_name": "Shadow",
+      "name": "shadow-animated",
+      "shine": 3
+    },
+    "class_royalties": [
+      {
+        "percentage": 0.8,
+        "recipient": "starkware"
+      },
+      {
+        "percentage": 2.4,
+        "recipient": "gu"
+      },
+      {
+        "percentage": 0.8,
+        "recipient": "gu-staking"
+      }
+    ],
+    "class_type": "card",
+    "game_id": 1
+  },
+  {
+    "class_key": "quality",
+    "class_value": "34",
+    "class_properties": {
+      "comp-frame": "{type}_meteorite",
+      "comp-rosette": "{god}_meteorite_animated",
+      "comp-tribe": "tribebar_meteorite",
+      "comp-wreath": "wreath_meteorite",
+      "frame": "meteorite",
+      "illustration": "animated",
+      "meta-quality_name": "Meteorite",
+      "name": "meteorite-animated",
+      "shine": 4
+    },
+    "class_royalties": [
+      {
+        "percentage": 1,
+        "recipient": "starkware"
+      },
+      {
+        "percentage": 3,
+        "recipient": "gu"
+      },
+      {
+        "percentage": 1,
+        "recipient": "gu-staking"
+      }
+    ],
+    "class_type": "card",
+    "game_id": 1
+  }
+]

--- a/artist/export-card.js
+++ b/artist/export-card.js
@@ -1,32 +1,31 @@
-// Exports a rendered <composited-card> element to a self-contained,
-// transparent SVG file.
+// Exports a rendered <composited-card> element to native SVG (and PNG).
 //
-// The card is a Shadow DOM tree of several stacked <picture>/<img> layers
-// plus two nested custom elements (<autofit-description-text>,
-// <card-icon>), each with their own shadow root. None of that is visible to
-// a plain DOM serializer, so this recursively "flattens" every shadow root
-// into plain markup, inlines each element's own CSS (extracted from
-// adoptedStyleSheets, since that's how lit-element 2.x attaches styles in
-// browsers that support Constructable StyleSheets), and bakes every image
-// into a data: URI. The border-layer images and card fonts are hosted on
-// images.godsunchained.com with no CORS headers, so they're routed through
-// the /proxy endpoint (see webpack.artist.config.js) first.
+// Earlier versions used <foreignObject> to embed real HTML/CSS, reusing the
+// browser's own layout for free. That hit two hard walls:
+//  1. Any SVG containing foreignObject is treated as tainting a <canvas> on
+//     export, unconditionally — even with zero remaining external
+//     references, fully self-contained (confirmed empirically) — so PNG
+//     export via canvas.toBlob() was blocked outright.
+//  2. foreignObject's HTML content is only rendered by real browser
+//     engines. Figma, Inkscape, rsvg-convert etc. implement the *native*
+//     SVG paint model (rect/image/text/path) and either skip foreignObject
+//     entirely or render it blank — so the file was only ever viewable in
+//     a browser tab.
 //
-// This originally tried to rasterize the result to a PNG via
-// <canvas>.toBlob(), but browsers unconditionally treat any SVG containing
-// <foreignObject> as tainting the canvas on export, regardless of whether
-// its content is actually fully self-contained (verified empirically —
-// zero remaining external references, still tainted). That's a browser
-// security policy, not something fixable by inlining harder, so this
-// exports the SVG directly instead — same real transparency, no canvas
-// step, no tainting possible. Any browser can open it directly, and it can
-// be converted to PNG with a free tool (eg. Inkscape) if needed.
+// This version avoids foreignObject entirely: every image layer becomes a
+// native SVG <image>, every piece of text becomes a native SVG <text>,
+// positioned and styled by reading the already-rendered live DOM directly
+// (getBoundingClientRect + getComputedStyle) rather than re-implementing
+// CSS layout by hand. That's portable to any SVG-compliant tool, and since
+// the taint rule is specifically about foreignObject's presence rather than
+// content, it also unblocks real canvas-based PNG export again.
 //
 // Font fidelity: "Unchained" (name/mana/attack/health/tribe text) and
-// "cardi-cons" (the set-icon ligature) are embedded. "Open Sans" (effect
-// text) is not — it's dynamically subsetted per-browser by Google Fonts,
-// which isn't practical to replicate byte-for-byte here, so effect text
-// falls back to the CSS's own generic sans-serif fallback instead.
+// "cardi-cons" (the set-icon ligature) are embedded via a plain SVG
+// @font-face (not inside foreignObject, so it's part of the actual SVG
+// spec). "Open Sans" (effect text) is not — it's dynamically subsetted
+// per-browser by Google Fonts, impractical to replicate byte-for-byte, so
+// effect text uses the CSS's own generic sans-serif fallback instead.
 
 const FONT_URLS = {
   unchained: 'https://images.godsunchained.com/fonts/unchained/unchained.woff2',
@@ -80,126 +79,244 @@ async function buildFontFaceCss() {
   `;
 }
 
-// lit-element 2.x uses Constructable StyleSheets (shadowRoot.adoptedStyleSheets)
-// in browsers that support it, rather than a literal <style> child node —
-// so a plain childNodes walk won't find the CSS at all.
-function extractAdoptedCss(shadowRoot) {
-  const sheets = shadowRoot.adoptedStyleSheets || [];
-  if (sheets.length) {
-    return sheets
-      .map((sheet) => Array.from(sheet.cssRules).map((rule) => rule.cssText).join('\n'))
-      .join('\n');
-  }
-  return Array.from(shadowRoot.querySelectorAll('style'))
-    .map((style) => style.textContent)
+function escapeXmlText(str) {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function escapeXmlAttr(str) {
+  return escapeXmlText(str).replace(/"/g, '&quot;');
+}
+
+function applyTextTransform(text, transform) {
+  if (transform === 'capitalize') return text.replace(/\b\w/g, (c) => c.toUpperCase());
+  if (transform === 'uppercase') return text.toUpperCase();
+  if (transform === 'lowercase') return text.toLowerCase();
+  return text;
+}
+
+// SVG <text> doesn't auto-wrap, so multi-line text (the effect/description
+// text) needs its actual browser-computed visual lines extracted, rather
+// than reimplementing word-wrap by hand. Splits into words (keeping a
+// widow-prevention &nbsp; glued to its neighbor, since it's not a regular
+// space), measures each word's rect via Range, then groups words sharing a
+// "top" into lines.
+function extractWrappedLines(el) {
+  const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+  const textNodes = [];
+  let n;
+  while ((n = walker.nextNode())) textNodes.push(n);
+  if (!textNodes.length) return [];
+
+  const words = [];
+  textNodes.forEach((textNode) => {
+    const content = textNode.textContent;
+    let start = 0;
+    for (let i = 0; i <= content.length; i++) {
+      const atBoundary = i === content.length || content[i] === ' ';
+      if (atBoundary) {
+        if (i > start) words.push({ node: textNode, start, end: i, text: content.slice(start, i) });
+        start = i + 1;
+      }
+    }
+  });
+  if (!words.length) return [];
+
+  const range = document.createRange();
+  const wordRects = words.map((w) => {
+    range.setStart(w.node, w.start);
+    range.setEnd(w.node, w.end);
+    return { text: w.text, rect: range.getBoundingClientRect() };
+  });
+
+  const lines = [];
+  wordRects.forEach((w) => {
+    const line = lines.find((l) => Math.abs(l.top - w.rect.top) < 2);
+    if (line) {
+      line.words.push(w.text);
+      line.left = Math.min(line.left, w.rect.left);
+      line.right = Math.max(line.right, w.rect.right);
+      line.bottom = Math.max(line.bottom, w.rect.bottom);
+    } else {
+      lines.push({ top: w.rect.top, bottom: w.rect.bottom, left: w.rect.left, right: w.rect.right, words: [w.text] });
+    }
+  });
+
+  return lines
+    .sort((a, b) => a.top - b.top)
+    .map((l) => ({ top: l.top, bottom: l.bottom, left: l.left, right: l.right, text: l.words.join(' ') }));
+}
+
+// SVG's dominant-baseline="hanging" (used to align by the top of the line
+// rather than doing baseline math by hand) isn't reliably implemented —
+// it rendered noticeably higher than the glyphs' actual top edge. Instead,
+// measure the real font ascent via Canvas's TextMetrics (which reflects
+// the exact font/size actually used) and position by the standard
+// alphabetic baseline, which every SVG renderer supports correctly.
+//
+// Built from the individual longhand properties rather than the
+// getComputedStyle(...).font shorthand — that shorthand can silently
+// compute to an empty string for some elements (eg. card-icon's ligature
+// span) if not every sub-property cleanly round-trips, and ctx.font
+// silently no-ops on an empty string, leaving canvas at its 10px sans-serif
+// default and producing a wildly wrong ascent.
+let measureCanvasCtx = null;
+function getFontAscent(cs, fontSize) {
+  if (!measureCanvasCtx) measureCanvasCtx = document.createElement('canvas').getContext('2d');
+  const weight = cs.fontWeight && cs.fontWeight !== 'normal' ? `${cs.fontWeight} ` : '';
+  measureCanvasCtx.font = `${weight}${cs.fontSize} ${cs.fontFamily}`;
+  const metrics = measureCanvasCtx.measureText('Hg');
+  return metrics.fontBoundingBoxAscent || metrics.actualBoundingBoxAscent || fontSize * 0.8;
+}
+
+function emitTextElements(el, cardRect) {
+  const cs = getComputedStyle(el);
+  const fontSize = parseFloat(cs.fontSize);
+  if (!fontSize) return '';
+  const lines = extractWrappedLines(el);
+  if (!lines.length) return '';
+
+  const hasShadow = cs.textShadow && cs.textShadow !== 'none';
+  const strokeAttrs = hasShadow
+    ? ` stroke="black" stroke-width="${(fontSize * 0.09).toFixed(2)}" paint-order="stroke fill"`
+    : '';
+  const ascent = getFontAscent(cs, fontSize);
+
+  return lines
+    .map((line) => {
+      const text = applyTextTransform(line.text, cs.textTransform);
+      const x = (line.left + line.right) / 2 - cardRect.left;
+      const y = line.top - cardRect.top + ascent;
+      return `<text x="${x.toFixed(2)}" y="${y.toFixed(2)}" text-anchor="middle" font-family="${escapeXmlAttr(cs.fontFamily)}" font-size="${fontSize.toFixed(2)}" font-weight="${cs.fontWeight}" fill="${cs.color}"${strokeAttrs}>${escapeXmlText(text)}</text>`;
+    })
     .join('\n');
 }
 
-async function flattenElement(el, cssChunks) {
-  const clone = document.createElement(el.tagName.toLowerCase());
-  Array.from(el.attributes || []).forEach((attr) => {
-    if (attr.name === 'srcset' || attr.name === 'sizes') return;
-    clone.setAttribute(attr.name, attr.value);
-  });
+async function emitImageElement(img, cardRect) {
+  const rect = img.getBoundingClientRect();
+  if (!rect.width || !rect.height) return '';
+  const src = img.currentSrc || img.src;
+  if (!src) return '';
 
-  const childSource = el.shadowRoot ? el.shadowRoot.childNodes : el.childNodes;
-  // Once flattened there's no shadow boundary left for :host to mean
-  // anything — rewrite it to target this element by its own tag name.
-  // Applies both to adoptedStyleSheets CSS and to per-instance <style>
-  // tags rendered directly in a component's template (eg.
-  // autofit-description-text embeds its own :host {...} block that way,
-  // not via adoptedStyleSheets, for its dynamic per-render positioning).
-  const hostTagName = el.shadowRoot ? el.tagName.toLowerCase() : null;
+  let href;
+  try {
+    href = await urlToDataUri(src);
+  } catch (err) {
+    return '';
+  }
+
+  const cs = getComputedStyle(img);
+  // object-fit:cover crops-to-fill, matched by SVG's "slice"; the default
+  // (no object-fit, ie. CSS "fill") stretches, matched by "none".
+  const preserveAspectRatio = cs.objectFit === 'cover' ? 'xMidYMid slice' : 'none';
+  // NOTE: deliberately not copying cs.transform here — getBoundingClientRect()
+  // already reflects any CSS transform (eg. the frame layers' small
+  // translate(4.3%, 0.2%) crop nudge) in the rect below, so re-applying it
+  // via an SVG transform attribute would double the shift.
+
+  const x = rect.left - cardRect.left;
+  const y = rect.top - cardRect.top;
+  return `<image x="${x.toFixed(2)}" y="${y.toFixed(2)}" width="${rect.width.toFixed(2)}" height="${rect.height.toFixed(2)}" href="${href}" preserveAspectRatio="${preserveAspectRatio}"/>`;
+}
+
+// Walks the card's shadow tree (and nested shadow roots, eg.
+// autofit-description-text/card-icon) to collect paint-ordered SVG parts.
+// Generic by structure rather than hardcoded class names, since
+// compositionVersion 1 vs 2 produce different DOM shapes but the same
+// class names/leaf-text pattern either way.
+async function collectSvgParts(el, cardRect, parts) {
   if (el.shadowRoot) {
-    const css = extractAdoptedCss(el.shadowRoot);
-    if (css) cssChunks.push(css.replace(/:host/g, hostTagName));
-  }
-  for (const child of Array.from(childSource)) {
-    // eslint-disable-next-line no-await-in-loop
-    await appendFlattened(clone, child, cssChunks, hostTagName);
-  }
-
-  if (el.tagName === 'IMG') {
-    const src = el.currentSrc || el.src;
-    if (src) {
-      try {
-        clone.setAttribute('src', await urlToDataUri(src));
-      } catch (err) {
-        // leave this one image broken rather than fail the whole export
-      }
+    for (const child of Array.from(el.shadowRoot.children)) {
+      // eslint-disable-next-line no-await-in-loop
+      await collectSvgParts(child, cardRect, parts);
     }
+    return;
   }
 
-  return clone;
+  if (el.tagName === 'STYLE' || el.tagName === 'SCRIPT') return;
+
+  if (el.tagName === 'PICTURE') {
+    const img = el.querySelector('img');
+    if (img) parts.push(await emitImageElement(img, cardRect));
+    return;
+  }
+  if (el.tagName === 'IMG') {
+    parts.push(await emitImageElement(el, cardRect));
+    return;
+  }
+
+  const hasDirectText = Array.from(el.childNodes).some(
+    (node) => node.nodeType === Node.TEXT_NODE && node.textContent.trim().length > 0,
+  );
+  const hasElementChildren = el.children.length > 0;
+
+  // A leaf with its own direct text (not just wrapping further elements) —
+  // eg. .card__manaText, .card__nameText__inner, the cardi-cons <i>, or
+  // autofit-description-text's .centered.
+  if (hasDirectText && !hasElementChildren) {
+    parts.push(emitTextElements(el, cardRect));
+    return;
+  }
+
+  for (const child of Array.from(el.children)) {
+    // eslint-disable-next-line no-await-in-loop
+    await collectSvgParts(child, cardRect, parts);
+  }
 }
 
-async function appendFlattened(parent, node, cssChunks, hostTagName) {
-  if (node.nodeType === Node.TEXT_NODE) {
-    parent.appendChild(document.createTextNode(node.textContent));
-    return;
-  }
-  if (node.nodeType !== Node.ELEMENT_NODE) return;
-
-  if (node.tagName === 'STYLE') {
-    const styleClone = document.createElement('style');
-    styleClone.textContent = hostTagName ? node.textContent.replace(/:host/g, hostTagName) : node.textContent;
-    parent.appendChild(styleClone);
-    return;
-  }
-
-  if (node.tagName === 'PICTURE') {
-    // Drop the <source> candidates — the exact resource is already baked
-    // in via currentSrc, no need to re-negotiate format/size for the
-    // export — but keep the <picture> element itself: its positioning CSS
-    // class (eg. "card__artwork") lives on the <picture>, not the <img>.
-    const img = node.querySelector('img');
-    const pictureClone = document.createElement('picture');
-    Array.from(node.attributes || []).forEach((attr) => pictureClone.setAttribute(attr.name, attr.value));
-    if (img) pictureClone.appendChild(await flattenElement(img, cssChunks));
-    parent.appendChild(pictureClone);
-    return;
-  }
-
-  parent.appendChild(await flattenElement(node, cssChunks));
-}
-
-export async function exportCardAsSvg(cardElement) {
-  const rect = cardElement.getBoundingClientRect();
-  const width = Math.round(rect.width);
-  const height = Math.round(rect.height);
+async function buildSvgMarkup(cardElement) {
+  const cardRect = cardElement.getBoundingClientRect();
+  const width = Math.round(cardRect.width);
+  const height = Math.round(cardRect.height);
   if (!width || !height) throw new Error('card has no rendered size to export');
 
-  const cssChunks = [];
-  const [flattenedCard, fontCss] = await Promise.all([
-    flattenElement(cardElement, cssChunks),
-    buildFontFaceCss(),
-  ]);
-  flattenedCard.setAttribute('style', `width:${width}px;height:${height}px;display:flex;`);
+  const parts = [];
+  await collectSvgParts(cardElement, cardRect, parts);
+  const fontCss = await buildFontFaceCss();
 
-  // outerHTML follows HTML serialization rules (void elements like <img>
-  // never self-close), which is invalid inside an XML/SVG document.
-  // XMLSerializer follows XML rules instead — self-closes empty elements,
-  // which foreignObject content requires.
-  const flattenedMarkup = new XMLSerializer().serializeToString(flattenedCard);
-  const styleEl = document.createElement('style');
-  styleEl.textContent = `${fontCss}\n${cssChunks.join('\n')}`;
-  const styleMarkup = new XMLSerializer().serializeToString(styleEl);
-
-  const svgMarkup = `
-    <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">
-      <foreignObject width="100%" height="100%">
-        <div xmlns="http://www.w3.org/1999/xhtml" style="width:${width}px;height:${height}px;">
-          ${styleMarkup}
-          ${flattenedMarkup}
-        </div>
-      </foreignObject>
-    </svg>
-  `;
+  const svgMarkup = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+  <style>${fontCss}</style>
+  ${parts.filter(Boolean).join('\n  ')}
+</svg>`;
 
   const parserErrorEl = new DOMParser().parseFromString(svgMarkup, 'image/svg+xml').querySelector('parsererror');
   if (parserErrorEl) {
     throw new Error(`generated SVG is not valid XML: ${parserErrorEl.textContent.slice(0, 300)}`);
   }
 
+  return { svgMarkup, width, height };
+}
+
+export async function exportCardAsSvg(cardElement) {
+  const { svgMarkup } = await buildSvgMarkup(cardElement);
   return new Blob([svgMarkup], { type: 'image/svg+xml;charset=utf-8' });
+}
+
+export async function exportCardAsPng(cardElement) {
+  const { svgMarkup, width, height } = await buildSvgMarkup(cardElement);
+  const svgUrl = URL.createObjectURL(new Blob([svgMarkup], { type: 'image/svg+xml;charset=utf-8' }));
+
+  try {
+    const img = new Image();
+    img.width = width;
+    img.height = height;
+    await new Promise((resolve, reject) => {
+      img.onload = resolve;
+      img.onerror = () => reject(new Error('failed to rasterize the exported svg'));
+      img.src = svgUrl;
+    });
+
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    canvas.getContext('2d').drawImage(img, 0, 0, width, height);
+
+    return await new Promise((resolve, reject) => {
+      canvas.toBlob((blob) => {
+        if (blob) resolve(blob);
+        else reject(new Error('canvas export failed (possibly a tainted canvas)'));
+      }, 'image/png');
+    });
+  } finally {
+    URL.revokeObjectURL(svgUrl);
+  }
 }

--- a/artist/export-card.js
+++ b/artist/export-card.js
@@ -1,0 +1,205 @@
+// Exports a rendered <composited-card> element to a self-contained,
+// transparent SVG file.
+//
+// The card is a Shadow DOM tree of several stacked <picture>/<img> layers
+// plus two nested custom elements (<autofit-description-text>,
+// <card-icon>), each with their own shadow root. None of that is visible to
+// a plain DOM serializer, so this recursively "flattens" every shadow root
+// into plain markup, inlines each element's own CSS (extracted from
+// adoptedStyleSheets, since that's how lit-element 2.x attaches styles in
+// browsers that support Constructable StyleSheets), and bakes every image
+// into a data: URI. The border-layer images and card fonts are hosted on
+// images.godsunchained.com with no CORS headers, so they're routed through
+// the /proxy endpoint (see webpack.artist.config.js) first.
+//
+// This originally tried to rasterize the result to a PNG via
+// <canvas>.toBlob(), but browsers unconditionally treat any SVG containing
+// <foreignObject> as tainting the canvas on export, regardless of whether
+// its content is actually fully self-contained (verified empirically —
+// zero remaining external references, still tainted). That's a browser
+// security policy, not something fixable by inlining harder, so this
+// exports the SVG directly instead — same real transparency, no canvas
+// step, no tainting possible. Any browser can open it directly, and it can
+// be converted to PNG with a free tool (eg. Inkscape) if needed.
+//
+// Font fidelity: "Unchained" (name/mana/attack/health/tribe text) and
+// "cardi-cons" (the set-icon ligature) are embedded. "Open Sans" (effect
+// text) is not — it's dynamically subsetted per-browser by Google Fonts,
+// which isn't practical to replicate byte-for-byte here, so effect text
+// falls back to the CSS's own generic sans-serif fallback instead.
+
+const FONT_URLS = {
+  unchained: 'https://images.godsunchained.com/fonts/unchained/unchained.woff2',
+  cardiCons: 'https://images.godsunchained.com/fonts/cardi-cons/cardi-cons.woff',
+};
+
+function isSameOrigin(url) {
+  try {
+    return new URL(url, window.location.href).origin === window.location.origin;
+  } catch (err) {
+    return true;
+  }
+}
+
+function proxiedUrl(url) {
+  return isSameOrigin(url) ? url : `/proxy?url=${encodeURIComponent(url)}`;
+}
+
+function urlToDataUri(url) {
+  return fetch(proxiedUrl(url))
+    .then((res) => res.blob())
+    .then(
+      (blob) =>
+        new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () => resolve(reader.result);
+          reader.onerror = reject;
+          reader.readAsDataURL(blob);
+        }),
+    );
+}
+
+async function buildFontFaceCss() {
+  const [unchained, cardiCons] = await Promise.all([
+    urlToDataUri(FONT_URLS.unchained),
+    urlToDataUri(FONT_URLS.cardiCons),
+  ]);
+  return `
+    @font-face {
+      font-family: "Unchained";
+      src: url("${unchained}") format("woff2");
+      font-weight: 700;
+      font-style: normal;
+    }
+    @font-face {
+      font-family: "cardi-cons";
+      src: url("${cardiCons}") format("woff");
+      font-weight: normal;
+      font-style: normal;
+    }
+  `;
+}
+
+// lit-element 2.x uses Constructable StyleSheets (shadowRoot.adoptedStyleSheets)
+// in browsers that support it, rather than a literal <style> child node —
+// so a plain childNodes walk won't find the CSS at all.
+function extractAdoptedCss(shadowRoot) {
+  const sheets = shadowRoot.adoptedStyleSheets || [];
+  if (sheets.length) {
+    return sheets
+      .map((sheet) => Array.from(sheet.cssRules).map((rule) => rule.cssText).join('\n'))
+      .join('\n');
+  }
+  return Array.from(shadowRoot.querySelectorAll('style'))
+    .map((style) => style.textContent)
+    .join('\n');
+}
+
+async function flattenElement(el, cssChunks) {
+  const clone = document.createElement(el.tagName.toLowerCase());
+  Array.from(el.attributes || []).forEach((attr) => {
+    if (attr.name === 'srcset' || attr.name === 'sizes') return;
+    clone.setAttribute(attr.name, attr.value);
+  });
+
+  const childSource = el.shadowRoot ? el.shadowRoot.childNodes : el.childNodes;
+  // Once flattened there's no shadow boundary left for :host to mean
+  // anything — rewrite it to target this element by its own tag name.
+  // Applies both to adoptedStyleSheets CSS and to per-instance <style>
+  // tags rendered directly in a component's template (eg.
+  // autofit-description-text embeds its own :host {...} block that way,
+  // not via adoptedStyleSheets, for its dynamic per-render positioning).
+  const hostTagName = el.shadowRoot ? el.tagName.toLowerCase() : null;
+  if (el.shadowRoot) {
+    const css = extractAdoptedCss(el.shadowRoot);
+    if (css) cssChunks.push(css.replace(/:host/g, hostTagName));
+  }
+  for (const child of Array.from(childSource)) {
+    // eslint-disable-next-line no-await-in-loop
+    await appendFlattened(clone, child, cssChunks, hostTagName);
+  }
+
+  if (el.tagName === 'IMG') {
+    const src = el.currentSrc || el.src;
+    if (src) {
+      try {
+        clone.setAttribute('src', await urlToDataUri(src));
+      } catch (err) {
+        // leave this one image broken rather than fail the whole export
+      }
+    }
+  }
+
+  return clone;
+}
+
+async function appendFlattened(parent, node, cssChunks, hostTagName) {
+  if (node.nodeType === Node.TEXT_NODE) {
+    parent.appendChild(document.createTextNode(node.textContent));
+    return;
+  }
+  if (node.nodeType !== Node.ELEMENT_NODE) return;
+
+  if (node.tagName === 'STYLE') {
+    const styleClone = document.createElement('style');
+    styleClone.textContent = hostTagName ? node.textContent.replace(/:host/g, hostTagName) : node.textContent;
+    parent.appendChild(styleClone);
+    return;
+  }
+
+  if (node.tagName === 'PICTURE') {
+    // Drop the <source> candidates — the exact resource is already baked
+    // in via currentSrc, no need to re-negotiate format/size for the
+    // export — but keep the <picture> element itself: its positioning CSS
+    // class (eg. "card__artwork") lives on the <picture>, not the <img>.
+    const img = node.querySelector('img');
+    const pictureClone = document.createElement('picture');
+    Array.from(node.attributes || []).forEach((attr) => pictureClone.setAttribute(attr.name, attr.value));
+    if (img) pictureClone.appendChild(await flattenElement(img, cssChunks));
+    parent.appendChild(pictureClone);
+    return;
+  }
+
+  parent.appendChild(await flattenElement(node, cssChunks));
+}
+
+export async function exportCardAsSvg(cardElement) {
+  const rect = cardElement.getBoundingClientRect();
+  const width = Math.round(rect.width);
+  const height = Math.round(rect.height);
+  if (!width || !height) throw new Error('card has no rendered size to export');
+
+  const cssChunks = [];
+  const [flattenedCard, fontCss] = await Promise.all([
+    flattenElement(cardElement, cssChunks),
+    buildFontFaceCss(),
+  ]);
+  flattenedCard.setAttribute('style', `width:${width}px;height:${height}px;display:flex;`);
+
+  // outerHTML follows HTML serialization rules (void elements like <img>
+  // never self-close), which is invalid inside an XML/SVG document.
+  // XMLSerializer follows XML rules instead — self-closes empty elements,
+  // which foreignObject content requires.
+  const flattenedMarkup = new XMLSerializer().serializeToString(flattenedCard);
+  const styleEl = document.createElement('style');
+  styleEl.textContent = `${fontCss}\n${cssChunks.join('\n')}`;
+  const styleMarkup = new XMLSerializer().serializeToString(styleEl);
+
+  const svgMarkup = `
+    <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">
+      <foreignObject width="100%" height="100%">
+        <div xmlns="http://www.w3.org/1999/xhtml" style="width:${width}px;height:${height}px;">
+          ${styleMarkup}
+          ${flattenedMarkup}
+        </div>
+      </foreignObject>
+    </svg>
+  `;
+
+  const parserErrorEl = new DOMParser().parseFromString(svgMarkup, 'image/svg+xml').querySelector('parsererror');
+  if (parserErrorEl) {
+    throw new Error(`generated SVG is not valid XML: ${parserErrorEl.textContent.slice(0, 300)}`);
+  }
+
+  return new Blob([svgMarkup], { type: 'image/svg+xml;charset=utf-8' });
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "analyze:src": "NODE_OPTIONS=--openssl-legacy-provider webpack --config ./webpack.analyze.config.js",
     "build:docs": "NODE_OPTIONS=--openssl-legacy-provider webpack --config ./webpack.ghpages.prod.config.js",
     "dev:docs": "webpack-dev-server --config ./webpack.ghpages.dev.config.js",
-    "dev:demo": "webpack-dev-server --config ./webpack.demo.config.js"
+    "dev:demo": "webpack-dev-server --config ./webpack.demo.config.js",
+    "dev:artist": "webpack-dev-server --config ./webpack.artist.config.js"
   },
   "dependencies": {
     "@juggle/resize-observer": "^3.2.0",

--- a/src/templating.ts
+++ b/src/templating.ts
@@ -445,7 +445,7 @@ export const textLayersTemplate = ({
     fontSize: `${ch * 9.5}px`,
     bottom: `${ch * 4.5}px`,
     width: `${cw * 15}px`,
-    left: `${cw * 10.5}px`,
+    left: `${cw * 10.6}px`,
     textShadow,
   });
   const healthTextStyles = styleMap({
@@ -837,13 +837,13 @@ export const textLayersCompositionTemplate = ({
     fontSize: `${ch * 9.5}px`,
     bottom: `${ch * 4.5}px`,
     width: `${cw * 15}px`,
-    left: `${cw * 10.5}px`,
+    left: `${cw * 11.4}px`,
     textShadow,
   });
   const healthTextStyles = styleMap({
     fontSize: `${ch * 9.5}px`,
     width: `${cw * 16}px`,
-    bottom: `${ch * 4.6}px`,
+    bottom: `${ch * 4.3}px`,
     right: `${cw * 2.5}px`,
     textShadow,
   });

--- a/webpack.artist.config.js
+++ b/webpack.artist.config.js
@@ -1,0 +1,86 @@
+const path = require('path');
+const fs = require('fs');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+const UPLOAD_DIR = path.resolve(__dirname, 'artist/uploads');
+const UPLOAD_PATH = path.join(UPLOAD_DIR, 'custom-art.jpg');
+
+module.exports = {
+  mode: 'development',
+  devServer: {
+    contentBase: path.join(__dirname, 'artist'),
+    compress: true,
+    port: 9001,
+    open: true,
+    // The artwork upload endpoint and the fixed illustration path
+    // composited-card's illustrationSource override requests — always
+    // serves whatever was most recently uploaded, regardless of the
+    // size/extension requested, since there's only ever one file.
+    before: (app) => {
+      app.get(/^\/custom-art\/art2\/.+/, (req, res) => {
+        if (!fs.existsSync(UPLOAD_PATH)) {
+          res.status(404).end();
+          return;
+        }
+        res.set('Cache-Control', 'no-store');
+        res.type('jpg');
+        res.sendFile(UPLOAD_PATH);
+      });
+
+      app.get('/api/upload-art/status', (req, res) => {
+        res.json({ exists: fs.existsSync(UPLOAD_PATH) });
+      });
+
+      app.post('/api/upload-art', (req, res) => {
+        const chunks = [];
+        req.on('data', (chunk) => chunks.push(chunk));
+        req.on('end', () => {
+          fs.mkdirSync(UPLOAD_DIR, { recursive: true });
+          fs.writeFileSync(UPLOAD_PATH, Buffer.concat(chunks));
+          res.json({ ok: true });
+        });
+        req.on('error', (err) => res.status(500).json({ ok: false, error: err.message }));
+      });
+
+      app.delete('/api/upload-art', (req, res) => {
+        if (fs.existsSync(UPLOAD_PATH)) fs.unlinkSync(UPLOAD_PATH);
+        res.json({ ok: true });
+      });
+    },
+  },
+  entry: './artist/artist.js',
+  output: {
+    filename: 'artist-bundle.js',
+    path: path.resolve(__dirname, 'dist'),
+    publicPath: '/',
+  },
+  resolve: {
+    extensions: ['.js', '.ts', '.css'],
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: path.resolve(__dirname, 'artist/artist.html'),
+    }),
+  ],
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+      },
+      {
+        test: /\.css$/i,
+        use: ['style-loader', 'css-loader'],
+      },
+      {
+        test: /\.(woff2|png)$/i,
+        use: [
+          {
+            loader: 'url-loader',
+          },
+        ],
+      },
+    ],
+  },
+};

--- a/webpack.artist.config.js
+++ b/webpack.artist.config.js
@@ -5,6 +5,14 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const UPLOAD_DIR = path.resolve(__dirname, 'artist/uploads');
 const UPLOAD_PATH = path.join(UPLOAD_DIR, 'custom-art.jpg');
 
+// Assets composited-card pulls in (border layers, fonts) are hosted on
+// images.godsunchained.com with no CORS headers, so a browser <canvas>
+// can't read their pixels for PNG export without tainting. Node has no such
+// restriction, so this proxies just those hosts through our own origin —
+// browser then sees them as same-origin. Used only by the PNG export
+// feature, not by normal card rendering.
+const PROXY_ALLOWED_HOSTS = ['images.godsunchained.com', 'fonts.gstatic.com'];
+
 module.exports = {
   mode: 'development',
   devServer: {
@@ -45,6 +53,34 @@ module.exports = {
       app.delete('/api/upload-art', (req, res) => {
         if (fs.existsSync(UPLOAD_PATH)) fs.unlinkSync(UPLOAD_PATH);
         res.json({ ok: true });
+      });
+
+      app.get('/proxy', async (req, res) => {
+        const target = req.query.url;
+        let parsed;
+        try {
+          parsed = new URL(target);
+        } catch (err) {
+          res.status(400).json({ ok: false, error: 'invalid url' });
+          return;
+        }
+        if (!PROXY_ALLOWED_HOSTS.includes(parsed.hostname)) {
+          res.status(403).json({ ok: false, error: 'host not allowed' });
+          return;
+        }
+        try {
+          const upstream = await fetch(parsed.toString());
+          if (!upstream.ok) {
+            res.status(upstream.status).end();
+            return;
+          }
+          const buffer = Buffer.from(await upstream.arrayBuffer());
+          res.set('Cache-Control', 'public, max-age=3600');
+          res.set('Content-Type', upstream.headers.get('content-type') || 'application/octet-stream');
+          res.send(buffer);
+        } catch (err) {
+          res.status(502).json({ ok: false, error: err.message });
+        }
       });
     },
   },


### PR DESCRIPTION
# DO NOT MERGE INTO main

## What is this
A local tool for artists to preview a card's full frame/composition with their own custom illustration, without needing real card/proto data. Fill in the card data (type, name, rarity, set, tribe, mana, attack/health, effect, etc.) and upload a jpg to see it composited into an actual card — including background color and preview size controls. Inputs are saved to local storage, so they persist between reloads. Also support PNG and SVG export.


## How to use
Run command
```
$ yarn dev:artist
```

## Note
_This PR is created for the sake of informing_
This tool is meant to run locally on artist's machine

## Screenshot
<img width="1099" height="910" alt="Screenshot 2026-07-17 at 10 05 22" src="https://github.com/user-attachments/assets/6d237371-344f-47db-8c39-5203ffd624ef" />
